### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,4 +1,6 @@
 name: Swift
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/platacard/blimp/security/code-scanning/1](https://github.com/platacard/blimp/security/code-scanning/1)

To address the issue, add a `permissions` block to the workflow. Given that the jobs only check out code and build/test (no publishing, pushing, or commenting), the minimal correct permission is `contents: read`, which allows reading repository contents and is sufficient for `actions/checkout` and related steps. The `permissions` block can be added at the workflow root (recommended, as it applies to all jobs unless overridden). No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
