### PR TITLE
feat: CertificateInstaller + ProvisioningProfileInfo (keychain install support)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,7 @@ blimp maintenance list-devices --platform ios
 blimp maintenance register-device UDID-123 "iPhone 15" --platform ios
 blimp maintenance list-certs --type DEVELOPMENT
 blimp maintenance generate-cert --type DEVELOPMENT --platform ios --storage-path ./certs --passphrase pass
+blimp maintenance install-certs --type DEVELOPMENT --storage-path ./certs   # decrypt + import into keychain
 blimp maintenance remove-cert CERT-ID
 blimp maintenance list-profiles --name "Blimp*"
 blimp maintenance sync-profiles --bundle-ids com.app --platform ios --type development --storage-path ./certs
@@ -318,6 +319,12 @@ profiles/{platform}/{type}/{bundle-id}.mobileprovision   # Unencrypted
 
 Profile installation (`install-profiles`) extracts UUID via `security cms -D` and copies to:
 `~/Library/MobileDevice/Provisioning Profiles/{uuid}.mobileprovision`
+
+Certificate installation (`install-certs`) decrypts stored `.p12` files with the storage
+passphrase (`BLIMP_PASSPHRASE`) and imports them into the keychain via `security import`
+with codesign access; it also installs the Apple WWDR intermediate certificate when missing.
+Pass `--keychain-password` (or `KEYCHAIN_PASSWORD`) to suppress codesign UI prompts via
+`security set-key-partition-list`.
 
 ## Key Protocols
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,7 @@ Profile installation (`install-profiles`) extracts UUID via `security cms -D` an
 `~/Library/MobileDevice/Provisioning Profiles/{uuid}.mobileprovision`
 
 Certificate installation (`install-certs`) decrypts stored `.p12` files with the storage
-passphrase (`BLIMP_PASSPHRASE`) and imports them into the keychain via `security import`
+certificate password (`CERTIFICATES_PASSWORD`) and imports them into the keychain via `security import`
 with codesign access; it also installs the Apple WWDR intermediate certificate when missing.
 Pass `--keychain-password` (or `KEYCHAIN_PASSWORD`) to suppress codesign UI prompts via
 `security set-key-partition-list`.

--- a/Sources/CLI/BlimpCLI/SecretInput.swift
+++ b/Sources/CLI/BlimpCLI/SecretInput.swift
@@ -4,9 +4,8 @@ import Foundation
 
 /// Resolves a secret from environment, CLI argument, or interactive hidden input.
 func resolveSecret(cliValue: String?, environmentKey: String, prompt: String) throws -> String {
-    // Environment variable first (CI-friendly)
-    if let value = ProcessInfo.processInfo.environment[environmentKey] { return value }
     if let value = cliValue { return value }
+    if let value = ProcessInfo.processInfo.environment[environmentKey] { return value }
 
     guard isatty(STDIN_FILENO) == 1 else {
         throw ValidationError("No TTY to prompt for a secret. Set \(environmentKey) or pass it as an argument.")

--- a/Sources/CLI/BlimpCLI/SecretInput.swift
+++ b/Sources/CLI/BlimpCLI/SecretInput.swift
@@ -26,13 +26,13 @@ func resolveSecret(cliValue: String?, environmentKey: String, prompt: String) th
 private func readSecureInput() -> String? {
     var oldTermios = termios()
     guard tcgetattr(STDIN_FILENO, &oldTermios) == 0 else {
-        return readLine()
+        return nil
     }
 
     var newTermios = oldTermios
     newTermios.c_lflag &= ~UInt(ECHO)
     guard tcsetattr(STDIN_FILENO, TCSANOW, &newTermios) == 0 else {
-        return readLine()
+        return nil
     }
 
     defer {

--- a/Sources/CLI/BlimpCLI/SecretInput.swift
+++ b/Sources/CLI/BlimpCLI/SecretInput.swift
@@ -1,0 +1,32 @@
+import ArgumentParser
+import Darwin
+import Foundation
+
+/// Resolves a secret from environment, CLI argument, or interactive hidden input.
+func resolveSecret(cliValue: String?, environmentKey: String, prompt: String) throws -> String {
+    // Environment variable first (CI-friendly)
+    if let value = ProcessInfo.processInfo.environment[environmentKey] { return value }
+    if let value = cliValue { return value }
+
+    print(prompt, terminator: "")
+    guard let value = readSecureInput() else {
+        throw ValidationError("Failed to read secret input")
+    }
+    return value
+}
+
+private func readSecureInput() -> String? {
+    var oldTermios = termios()
+    tcgetattr(STDIN_FILENO, &oldTermios)
+
+    var newTermios = oldTermios
+    newTermios.c_lflag &= ~UInt(ECHO)
+    tcsetattr(STDIN_FILENO, TCSANOW, &newTermios)
+
+    let result = readLine()
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldTermios)
+    print()
+
+    return result
+}

--- a/Sources/CLI/BlimpCLI/SecretInput.swift
+++ b/Sources/CLI/BlimpCLI/SecretInput.swift
@@ -2,6 +2,11 @@ import ArgumentParser
 import Darwin
 import Foundation
 
+enum SecretEnvKey {
+    static let certificatesPassword = "CERTIFICATES_PASSWORD"
+    static let keychainPassword = "KEYCHAIN_PASSWORD"
+}
+
 /// Resolves a secret from environment, CLI argument, or interactive hidden input.
 func resolveSecret(cliValue: String?, environmentKey: String, prompt: String) throws -> String {
     if let value = cliValue { return value }

--- a/Sources/CLI/BlimpCLI/SecretInput.swift
+++ b/Sources/CLI/BlimpCLI/SecretInput.swift
@@ -8,6 +8,10 @@ func resolveSecret(cliValue: String?, environmentKey: String, prompt: String) th
     if let value = ProcessInfo.processInfo.environment[environmentKey] { return value }
     if let value = cliValue { return value }
 
+    guard isatty(STDIN_FILENO) == 1 else {
+        throw ValidationError("No TTY to prompt for a secret. Set \(environmentKey) or pass it as an argument.")
+    }
+
     print(prompt, terminator: "")
     guard let value = readSecureInput() else {
         throw ValidationError("Failed to read secret input")

--- a/Sources/CLI/BlimpCLI/SecretInput.swift
+++ b/Sources/CLI/BlimpCLI/SecretInput.swift
@@ -21,16 +21,20 @@ func resolveSecret(cliValue: String?, environmentKey: String, prompt: String) th
 
 private func readSecureInput() -> String? {
     var oldTermios = termios()
-    tcgetattr(STDIN_FILENO, &oldTermios)
+    guard tcgetattr(STDIN_FILENO, &oldTermios) == 0 else {
+        return readLine()
+    }
 
     var newTermios = oldTermios
     newTermios.c_lflag &= ~UInt(ECHO)
-    tcsetattr(STDIN_FILENO, TCSANOW, &newTermios)
+    guard tcsetattr(STDIN_FILENO, TCSANOW, &newTermios) == 0 else {
+        return readLine()
+    }
 
-    let result = readLine()
+    defer {
+        tcsetattr(STDIN_FILENO, TCSANOW, &oldTermios)
+        print()
+    }
 
-    tcsetattr(STDIN_FILENO, TCSANOW, &oldTermios)
-    print()
-
-    return result
+    return readLine()
 }

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Maintenance.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Maintenance.swift
@@ -15,6 +15,7 @@ struct Maintenance: AsyncParsableCommand {
             // Certificates
             ListCertificates.self,
             GenerateCertificate.self,
+            InstallCertificates.self,
             RevokeCertificate.self,
             // Profiles
             ListProfiles.self,

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -19,14 +19,14 @@ struct GenerateCertificate: AsyncParsableCommand {
     @Option(help: "Storage path")
     var storagePath: String = "."
 
-    @Option(help: "Passphrase (or set BLIMP_PASSPHRASE, or enter interactively)")
+    @Option(help: "Certificate password (or set CERTIFICATES_PASSWORD, or enter interactively)")
     var passphrase: String?
 
     func run() async throws {
         let logger = Cronista(module: "blimp", category: "Maintenance")
         let passphrase = try resolveSecret(
             cliValue: passphrase,
-            environmentKey: "BLIMP_PASSPHRASE",
+            environmentKey: "CERTIFICATES_PASSWORD",
             prompt: "Enter passphrase: "
         )
         let resolvedPath = storagePath == "." ? FileManager.default.currentDirectoryPath : storagePath

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -22,6 +22,9 @@ struct GenerateCertificate: AsyncParsableCommand {
     @Option(help: "Certificate password (or set \(SecretEnvKey.certificatesPassword), or enter interactively)")
     var passphrase: String?
 
+    @Flag(help: "Push to remote after committing")
+    var push: Bool = false
+
     func run() async throws {
         let logger = Cronista(module: "blimp", category: "Maintenance")
         let passphrase = try resolveSecret(
@@ -35,7 +38,8 @@ struct GenerateCertificate: AsyncParsableCommand {
             type: type,
             platform: platform,
             storagePath: resolvedPath,
-            passphrase: passphrase
+            passphrase: passphrase,
+            push: push
         )
 
         logger.info("Certificate created successfully")

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -24,7 +24,11 @@ struct GenerateCertificate: AsyncParsableCommand {
 
     func run() async throws {
         let logger = Cronista(module: "blimp", category: "Maintenance")
-        let passphrase = try resolvePassphrase(passphrase)
+        let passphrase = try resolveSecret(
+            cliValue: passphrase,
+            environmentKey: "BLIMP_PASSPHRASE",
+            prompt: "Enter passphrase: "
+        )
         let resolvedPath = storagePath == "." ? FileManager.default.currentDirectoryPath : storagePath
 
         let cert = try await Blimp.Maintenance.default.generateCertificate(
@@ -38,35 +42,4 @@ struct GenerateCertificate: AsyncParsableCommand {
         logger.info("  ID: \(cert.id)")
         logger.info("  Name: \(cert.name)")
     }
-}
-
-// MARK: - Passphrase interactive input
-
-private func resolvePassphrase(_ cliValue: String?) throws -> String {
-    // Environment variable first (CI-friendly)
-    if let value = ProcessInfo.processInfo.environment["BLIMP_PASSPHRASE"] { return value }
-    if let value = cliValue { return value }
-
-    // Interactive fallback
-    print("Enter passphrase: ", terminator: "")
-    guard let pass = readSecureInput() else {
-        throw ValidationError("Failed to read passphrase")
-    }
-    return pass
-}
-
-private func readSecureInput() -> String? {
-    var oldTermios = termios()
-    tcgetattr(STDIN_FILENO, &oldTermios)
-
-    var newTermios = oldTermios
-    newTermios.c_lflag &= ~UInt(ECHO)
-    tcsetattr(STDIN_FILENO, TCSANOW, &newTermios)
-
-    let result = readLine()
-
-    tcsetattr(STDIN_FILENO, TCSANOW, &oldTermios)
-    print()
-
-    return result
 }

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -19,14 +19,14 @@ struct GenerateCertificate: AsyncParsableCommand {
     @Option(help: "Storage path")
     var storagePath: String = "."
 
-    @Option(help: "Certificate password (or set CERTIFICATES_PASSWORD, or enter interactively)")
+    @Option(help: "Certificate password (or set \(SecretEnvKey.certificatesPassword), or enter interactively)")
     var passphrase: String?
 
     func run() async throws {
         let logger = Cronista(module: "blimp", category: "Maintenance")
         let passphrase = try resolveSecret(
             cliValue: passphrase,
-            environmentKey: "CERTIFICATES_PASSWORD",
+            environmentKey: SecretEnvKey.certificatesPassword,
             prompt: "Enter passphrase: "
         )
         let resolvedPath = storagePath == "." ? FileManager.default.currentDirectoryPath : storagePath

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/InstallCertificates.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/InstallCertificates.swift
@@ -25,7 +25,7 @@ struct InstallCertificates: AsyncParsableCommand {
     @Option(help: "Keychain password for codesign access without UI prompts (or set KEYCHAIN_PASSWORD)")
     var keychainPassword: String?
 
-    @Option(help: "Passphrase (or set BLIMP_PASSPHRASE, or enter interactively)")
+    @Option(help: "Certificate password (or set CERTIFICATES_PASSWORD, or enter interactively)")
     var passphrase: String?
 
     @Flag(help: "Skip installing the Apple WWDR intermediate certificate")
@@ -35,7 +35,7 @@ struct InstallCertificates: AsyncParsableCommand {
         let logger = Cronista(module: "blimp", category: "Maintenance")
         let passphrase = try resolveSecret(
             cliValue: passphrase,
-            environmentKey: "BLIMP_PASSPHRASE",
+            environmentKey: "CERTIFICATES_PASSWORD",
             prompt: "Enter passphrase: "
         )
         let keychainPassword = self.keychainPassword ?? ProcessInfo.processInfo.environment["KEYCHAIN_PASSWORD"]

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/InstallCertificates.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/InstallCertificates.swift
@@ -22,10 +22,10 @@ struct InstallCertificates: AsyncParsableCommand {
     @Option(help: "Keychain path (defaults to login keychain)")
     var keychain: String?
 
-    @Option(help: "Keychain password for codesign access without UI prompts (or set KEYCHAIN_PASSWORD)")
+    @Option(help: "Keychain password for codesign access without UI prompts (or set \(SecretEnvKey.keychainPassword))")
     var keychainPassword: String?
 
-    @Option(help: "Certificate password (or set CERTIFICATES_PASSWORD, or enter interactively)")
+    @Option(help: "Certificate password (or set \(SecretEnvKey.certificatesPassword), or enter interactively)")
     var passphrase: String?
 
     @Flag(help: "Skip installing the Apple WWDR intermediate certificate")
@@ -35,10 +35,10 @@ struct InstallCertificates: AsyncParsableCommand {
         let logger = Cronista(module: "blimp", category: "Maintenance")
         let passphrase = try resolveSecret(
             cliValue: passphrase,
-            environmentKey: "CERTIFICATES_PASSWORD",
+            environmentKey: SecretEnvKey.certificatesPassword,
             prompt: "Enter passphrase: "
         )
-        let keychainPassword = self.keychainPassword ?? ProcessInfo.processInfo.environment["KEYCHAIN_PASSWORD"]
+        let keychainPassword = self.keychainPassword ?? ProcessInfo.processInfo.environment[SecretEnvKey.keychainPassword]
         let resolvedPath = storagePath == "." ? FileManager.default.currentDirectoryPath : storagePath
 
         let installer = CertificateInstaller(storagePath: resolvedPath)

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/InstallCertificates.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/InstallCertificates.swift
@@ -1,0 +1,60 @@
+import ArgumentParser
+import BlimpKit
+import Foundation
+import ProvisioningAPI
+import Cronista
+
+struct InstallCertificates: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install-certs",
+        abstract: "Install certificates from storage into the macOS keychain"
+    )
+
+    @Option(help: "Certificate type: development, distribution")
+    var type: ProvisioningAPI.CertificateType = .development
+
+    @Option(help: "Platform: ios, macos, tvos, catalyst")
+    var platform: ProvisioningAPI.Platform = .ios
+
+    @Option(help: "Storage path")
+    var storagePath: String = "."
+
+    @Option(help: "Keychain path (defaults to login keychain)")
+    var keychain: String?
+
+    @Option(help: "Keychain password for codesign access without UI prompts (or set KEYCHAIN_PASSWORD)")
+    var keychainPassword: String?
+
+    @Option(help: "Passphrase (or set BLIMP_PASSPHRASE, or enter interactively)")
+    var passphrase: String?
+
+    @Flag(help: "Skip installing the Apple WWDR intermediate certificate")
+    var skipWwdr = false
+
+    func run() async throws {
+        let logger = Cronista(module: "blimp", category: "Maintenance")
+        let passphrase = try resolveSecret(
+            cliValue: passphrase,
+            environmentKey: "BLIMP_PASSPHRASE",
+            prompt: "Enter passphrase: "
+        )
+        let keychainPassword = self.keychainPassword ?? ProcessInfo.processInfo.environment["KEYCHAIN_PASSWORD"]
+        let resolvedPath = storagePath == "." ? FileManager.default.currentDirectoryPath : storagePath
+
+        let installer = CertificateInstaller(storagePath: resolvedPath)
+
+        let installed = try await installer.installCertificates(
+            platform: platform,
+            type: type,
+            passphrase: passphrase,
+            keychain: keychain.map { .path($0) } ?? .login,
+            keychainPassword: keychainPassword,
+            installWWDR: !skipWwdr
+        )
+
+        logger.success("Installed \(installed.count) certificate(s):")
+        for cert in installed {
+            logger.info("  \(cert.certificateId) -> \(cert.keychainPath)")
+        }
+    }
+}

--- a/Sources/Domain/BlimpKit/CertificateInstaller.swift
+++ b/Sources/Domain/BlimpKit/CertificateInstaller.swift
@@ -122,11 +122,13 @@ public struct CertificateInstaller: Sendable {
         for fileName in certFiles {
             let certificateId = (fileName as NSString).deletingPathExtension
             let storedData = try await git.readFile(path: "\(certDir)/\(fileName)")
-            let p12Data = FileEncrypter.isEncrypted(storedData)
-                ? try encrypter.decrypt(data: storedData, password: passphrase)
-                : storedData
 
-            try importP12(p12Data, passphrase: passphrase, keychainPath: keychainPath)
+            try await installCertificate(
+                p12Data: storedData,
+                passphrase: passphrase,
+                keychain: keychain,
+                installWWDR: false
+            )
 
             installed.append(InstalledCertificate(certificateId: certificateId, type: type, keychainPath: keychainPath))
             logger.info("Imported certificate \(certificateId)")
@@ -138,6 +140,32 @@ public struct CertificateInstaller: Sendable {
 
         logger.info("Installed \(installed.count) certificate(s)")
         return installed
+    }
+
+    /// Installs a single p12 into the keychain, regardless of where it was stored.
+    /// Decrypts first when the data carries the OpenSSL `Salted__` header.
+    public func installCertificate(
+        p12Data: Data,
+        passphrase: String,
+        keychain: Keychain = .login,
+        keychainPassword: String? = nil,
+        installWWDR: Bool = true
+    ) async throws {
+        let keychainPath = keychain.resolvedPath
+
+        if installWWDR {
+            try await ensureWWDRCertificate(keychainPath: keychainPath)
+        }
+
+        let p12 = FileEncrypter.isEncrypted(p12Data)
+            ? try encrypter.decrypt(data: p12Data, password: passphrase)
+            : p12Data
+
+        try importP12(p12, passphrase: passphrase, keychainPath: keychainPath)
+
+        if let keychainPassword {
+            try allowCodesignAccess(keychainPath: keychainPath, keychainPassword: keychainPassword)
+        }
     }
 
     // MARK: - Private

--- a/Sources/Domain/BlimpKit/CertificateInstaller.swift
+++ b/Sources/Domain/BlimpKit/CertificateInstaller.swift
@@ -171,7 +171,16 @@ public struct CertificateInstaller: Sendable {
             try? FileManager.default.removeItem(at: tempFile)
         }
 
-        try p12Data.write(to: tempFile, options: [.completeFileProtection])
+        // Owner-only permissions: the file briefly holds the decrypted p12.
+        let created = FileManager.default.createFile(
+            atPath: tempFile.path,
+            contents: p12Data,
+            attributes: [.posixPermissions: 0o600]
+        )
+        guard created else {
+            throw Error.importFailed("Could not write temporary p12 file")
+        }
+
         _ = try shell.run(arguments: [
             "security", "import", tempFile.path,
             "-k", keychainPath,
@@ -203,11 +212,13 @@ public struct CertificateInstaller: Sendable {
     public enum Error: Swift.Error, LocalizedError {
         case noCertificatesFound(String)
         case wwdrUnavailable(String)
+        case importFailed(String)
 
         public var errorDescription: String? {
             switch self {
             case .noCertificatesFound(let msg): return msg
             case .wwdrUnavailable(let msg): return msg
+            case .importFailed(let msg): return msg
             }
         }
     }

--- a/Sources/Domain/BlimpKit/CertificateInstaller.swift
+++ b/Sources/Domain/BlimpKit/CertificateInstaller.swift
@@ -15,7 +15,12 @@ public struct URLWWDRCertificateProvider: WWDRCertificateProviding {
     public init() {}
 
     public func fetch() async throws -> Data {
-        let (data, _) = try await URLSession.shared.data(from: Self.certificateURL)
+        let (data, response) = try await URLSession.shared.data(from: Self.certificateURL)
+
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
         return data
     }
 }
@@ -35,8 +40,10 @@ public struct InstalledCertificate: Sendable {
 
 /// Installs signing certificates from Git storage into a macOS keychain.
 ///
-/// Reads encrypted `.p12` files from `certificates/<TYPE>/`, decrypts them with the
-/// storage passphrase, and imports them via `security import` with codesign access.
+/// Reads encrypted `.p12` files from the certificate storage directory
+/// (`certificates/<TYPE>/` for universal types, `certificates/<platform>/<TYPE>/` otherwise),
+/// decrypts them with the storage passphrase, and imports them via `security import`
+/// with codesign access.
 public struct CertificateInstaller: Sendable {
 
     public enum Keychain: Sendable {
@@ -49,7 +56,7 @@ public struct CertificateInstaller: Sendable {
                 return FileManager.default.homeDirectoryForCurrentUser
                     .appendingPathComponent("Library/Keychains/login.keychain-db").path
             case .path(let path):
-                return path
+                return (path as NSString).expandingTildeInPath
             }
         }
     }
@@ -113,7 +120,7 @@ public struct CertificateInstaller: Sendable {
         var installed: [InstalledCertificate] = []
 
         for fileName in certFiles {
-            let certificateId = fileName.replacingOccurrences(of: ".p12", with: "")
+            let certificateId = (fileName as NSString).deletingPathExtension
             let encryptedData = try await git.readFile(path: "\(certDir)/\(fileName)")
             let p12Data = try encrypter.decrypt(data: encryptedData, password: passphrase)
 

--- a/Sources/Domain/BlimpKit/CertificateInstaller.swift
+++ b/Sources/Domain/BlimpKit/CertificateInstaller.swift
@@ -40,10 +40,10 @@ public struct InstalledCertificate: Sendable {
 
 /// Installs signing certificates from Git storage into a macOS keychain.
 ///
-/// Reads encrypted `.p12` files from the certificate storage directory
-/// (`certificates/<TYPE>/` for universal types, `certificates/<platform>/<TYPE>/` otherwise),
-/// decrypts them with the storage passphrase, and imports them via `security import`
-/// with codesign access.
+/// Reads password-protected `.p12` files from the certificate storage directory
+/// (`certificates/<TYPE>/` for universal types, `certificates/<platform>/<TYPE>/` otherwise)
+/// and imports them via `security import` with codesign access. Files additionally
+/// encrypted at rest (OpenSSL `Salted__` header) are decrypted with the same passphrase first.
 public struct CertificateInstaller: Sendable {
 
     public enum Keychain: Sendable {
@@ -121,8 +121,10 @@ public struct CertificateInstaller: Sendable {
 
         for fileName in certFiles {
             let certificateId = (fileName as NSString).deletingPathExtension
-            let encryptedData = try await git.readFile(path: "\(certDir)/\(fileName)")
-            let p12Data = try encrypter.decrypt(data: encryptedData, password: passphrase)
+            let storedData = try await git.readFile(path: "\(certDir)/\(fileName)")
+            let p12Data = FileEncrypter.isEncrypted(storedData)
+                ? try encrypter.decrypt(data: storedData, password: passphrase)
+                : storedData
 
             try importP12(p12Data, passphrase: passphrase, keychainPath: keychainPath)
 

--- a/Sources/Domain/BlimpKit/CertificateInstaller.swift
+++ b/Sources/Domain/BlimpKit/CertificateInstaller.swift
@@ -171,7 +171,6 @@ public struct CertificateInstaller: Sendable {
             try? FileManager.default.removeItem(at: tempFile)
         }
 
-        // Owner-only permissions: the file briefly holds the decrypted p12.
         let created = FileManager.default.createFile(
             atPath: tempFile.path,
             contents: p12Data,

--- a/Sources/Domain/BlimpKit/CertificateInstaller.swift
+++ b/Sources/Domain/BlimpKit/CertificateInstaller.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Cronista
+import ProvisioningAPI
+import Gito
+
+/// Provides the Apple WWDR intermediate certificate. Enables testing without network access.
+public protocol WWDRCertificateProviding: Sendable {
+    func fetch() async throws -> Data
+}
+
+/// Downloads the WWDR G3 intermediate certificate from Apple.
+public struct URLWWDRCertificateProvider: WWDRCertificateProviding {
+    public static let certificateURL = URL(string: "https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer")!
+
+    public init() {}
+
+    public func fetch() async throws -> Data {
+        let (data, _) = try await URLSession.shared.data(from: Self.certificateURL)
+        return data
+    }
+}
+
+/// Result of installing a certificate into a keychain.
+public struct InstalledCertificate: Sendable {
+    public let certificateId: String
+    public let type: ProvisioningAPI.CertificateType
+    public let keychainPath: String
+
+    public init(certificateId: String, type: ProvisioningAPI.CertificateType, keychainPath: String) {
+        self.certificateId = certificateId
+        self.type = type
+        self.keychainPath = keychainPath
+    }
+}
+
+/// Installs signing certificates from Git storage into a macOS keychain.
+///
+/// Reads encrypted `.p12` files from `certificates/<TYPE>/`, decrypts them with the
+/// storage passphrase, and imports them via `security import` with codesign access.
+public struct CertificateInstaller: Sendable {
+
+    public enum Keychain: Sendable {
+        case login
+        case path(String)
+
+        var resolvedPath: String {
+            switch self {
+            case .login:
+                return FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent("Library/Keychains/login.keychain-db").path
+            case .path(let path):
+                return path
+            }
+        }
+    }
+
+    private let git: any GitManaging
+    private let shell: any ShellExecuting
+    private let encrypter: any EncryptionService
+    private let wwdrProvider: any WWDRCertificateProviding
+
+    nonisolated(unsafe) private let logger = Cronista(module: "blimp", category: "CertificateInstaller")
+
+    public init(
+        git: any GitManaging,
+        shell: any ShellExecuting = DefaultShellExecutor(),
+        encrypter: any EncryptionService = FileEncrypter(),
+        wwdrProvider: any WWDRCertificateProviding = URLWWDRCertificateProvider()
+    ) {
+        self.git = git
+        self.shell = shell
+        self.encrypter = encrypter
+        self.wwdrProvider = wwdrProvider
+    }
+
+    /// Convenience initializer over a local Git storage clone.
+    public init(storagePath: String) {
+        self.init(git: GitStorage(localPath: storagePath))
+    }
+
+    /// Installs all stored certificates of the given type into the keychain.
+    /// - Parameters:
+    ///   - passphrase: Storage passphrase, used both to decrypt the stored file and as the p12 import password.
+    ///   - keychainPassword: When provided, runs `security set-key-partition-list` so codesign
+    ///     can use the keys without a UI prompt.
+    public func installCertificates(
+        platform: ProvisioningAPI.Platform,
+        type: ProvisioningAPI.CertificateType,
+        passphrase: String,
+        keychain: Keychain = .login,
+        keychainPassword: String? = nil,
+        installWWDR: Bool = true
+    ) async throws -> [InstalledCertificate] {
+        logger.info("Installing certificates for \(platform.rawValue)/\(type.rawValue)")
+
+        try await git.cloneOrPull()
+
+        let keychainPath = keychain.resolvedPath
+
+        if installWWDR {
+            try await ensureWWDRCertificate(keychainPath: keychainPath)
+        }
+
+        let certDir = type.storageDirectory(for: platform)
+        let certFiles = try listCertificateFiles(in: certDir)
+
+        guard !certFiles.isEmpty else {
+            throw Error.noCertificatesFound("No .p12 files found in \(certDir)")
+        }
+
+        logger.info("Found \(certFiles.count) certificate(s) in storage")
+
+        var installed: [InstalledCertificate] = []
+
+        for fileName in certFiles {
+            let certificateId = fileName.replacingOccurrences(of: ".p12", with: "")
+            let encryptedData = try await git.readFile(path: "\(certDir)/\(fileName)")
+            let p12Data = try encrypter.decrypt(data: encryptedData, password: passphrase)
+
+            try importP12(p12Data, passphrase: passphrase, keychainPath: keychainPath)
+
+            installed.append(InstalledCertificate(certificateId: certificateId, type: type, keychainPath: keychainPath))
+            logger.info("Imported certificate \(certificateId)")
+        }
+
+        if let keychainPassword {
+            try allowCodesignAccess(keychainPath: keychainPath, keychainPassword: keychainPassword)
+        }
+
+        logger.info("Installed \(installed.count) certificate(s)")
+        return installed
+    }
+
+    // MARK: - Private
+
+    private func ensureWWDRCertificate(keychainPath: String) async throws {
+        let findResult = try? shell.run(arguments: [
+            "security", "find-certificate", "-c", "Apple Worldwide Developer Relations", keychainPath
+        ])
+
+        if findResult != nil {
+            logger.info("WWDR certificate already present")
+            return
+        }
+
+        logger.info("Fetching WWDR intermediate certificate")
+
+        let data: Data
+        do {
+            data = try await wwdrProvider.fetch()
+        } catch {
+            throw Error.wwdrUnavailable("Could not fetch the WWDR certificate: \(error.localizedDescription)")
+        }
+
+        let tempFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).cer")
+
+        defer {
+            try? FileManager.default.removeItem(at: tempFile)
+        }
+
+        try data.write(to: tempFile)
+        _ = try shell.run(arguments: ["security", "import", tempFile.path, "-k", keychainPath])
+    }
+
+    private func importP12(_ p12Data: Data, passphrase: String, keychainPath: String) throws {
+        let tempFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).p12")
+
+        defer {
+            try? FileManager.default.removeItem(at: tempFile)
+        }
+
+        try p12Data.write(to: tempFile, options: [.completeFileProtection])
+        _ = try shell.run(arguments: [
+            "security", "import", tempFile.path,
+            "-k", keychainPath,
+            "-P", passphrase,
+            "-T", "/usr/bin/codesign"
+        ])
+    }
+
+    private func allowCodesignAccess(keychainPath: String, keychainPassword: String) throws {
+        _ = try shell.run(arguments: [
+            "security", "set-key-partition-list",
+            "-S", "apple-tool:,apple:,codesign:",
+            "-s",
+            "-k", keychainPassword,
+            keychainPath
+        ])
+    }
+
+    private func listCertificateFiles(in directory: String) throws -> [String] {
+        let dirURL = git.localURL.appendingPathComponent(directory)
+        guard FileManager.default.fileExists(atPath: dirURL.path) else {
+            return []
+        }
+
+        let contents = try FileManager.default.contentsOfDirectory(atPath: dirURL.path)
+        return contents.filter { $0.hasSuffix(".p12") }.sorted()
+    }
+
+    public enum Error: Swift.Error, LocalizedError {
+        case noCertificatesFound(String)
+        case wwdrUnavailable(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .noCertificatesFound(let msg): return msg
+            case .wwdrUnavailable(let msg): return msg
+            }
+        }
+    }
+}

--- a/Sources/Domain/BlimpKit/Encryption/FileEncrypter.swift
+++ b/Sources/Domain/BlimpKit/Encryption/FileEncrypter.swift
@@ -21,6 +21,11 @@ public struct FileEncrypter: EncryptionService, Sendable {
 
     public init() {}
 
+    /// Whether the data carries the OpenSSL `Salted__` header produced by `encrypt`.
+    public static func isEncrypted(_ data: Data) -> Bool {
+        data.count >= magic.count && data.prefix(magic.count) == magic
+    }
+
     public func encrypt(data: Data, password: String) throws -> Data {
         let salt = try generateSalt()
         let (key, iv) = try deriveKeyAndIV(password: password, salt: salt)

--- a/Sources/Domain/BlimpKit/ProfileInstaller.swift
+++ b/Sources/Domain/BlimpKit/ProfileInstaller.swift
@@ -137,8 +137,9 @@ public struct ProfileInstaller: Sendable {
 
     /// Extracts UUID from a provisioning profile using `security cms -D`
     private func extractUUID(from profileData: Data) throws -> String {
-        guard let plist = try? ProvisioningProfileInfo.decodePlist(profileData: profileData, shell: shell),
-              let uuid = plist["UUID"] as? String else {
+        let plist = try ProvisioningProfileInfo.decodePlist(profileData: profileData, shell: shell)
+
+        guard let uuid = plist["UUID"] as? String else {
             throw Error.invalidProfile("Could not extract UUID from profile")
         }
 

--- a/Sources/Domain/BlimpKit/ProfileInstaller.swift
+++ b/Sources/Domain/BlimpKit/ProfileInstaller.swift
@@ -137,19 +137,7 @@ public struct ProfileInstaller: Sendable {
 
     /// Extracts UUID from a provisioning profile using `security cms -D`
     private func extractUUID(from profileData: Data) throws -> String {
-        let tempDir = FileManager.default.temporaryDirectory
-        let tempFile = tempDir.appendingPathComponent("\(UUID().uuidString).mobileprovision")
-
-        defer {
-            try? FileManager.default.removeItem(at: tempFile)
-        }
-
-        try profileData.write(to: tempFile)
-
-        let output = try shell.run(arguments: ["security", "cms", "-D", "-i", tempFile.path])
-
-        guard let plistData = output.data(using: .utf8),
-              let plist = try? PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any],
+        guard let plist = try? ProvisioningProfileInfo.decodePlist(profileData: profileData, shell: shell),
               let uuid = plist["UUID"] as? String else {
             throw Error.invalidProfile("Could not extract UUID from profile")
         }

--- a/Sources/Domain/BlimpKit/ProvisioningProfileInfo.swift
+++ b/Sources/Domain/BlimpKit/ProvisioningProfileInfo.swift
@@ -1,0 +1,101 @@
+import Foundation
+import ProvisioningAPI
+
+/// Parsed metadata of a `.mobileprovision` file.
+public struct ProvisioningProfileInfo: Sendable {
+    public let uuid: String
+    public let name: String
+    public let teamId: String
+    /// Application identifier without the team ID prefix. May be `*` for wildcard profiles.
+    public let bundleId: String
+    public let creationDate: Date
+    public let expirationDate: Date
+    public let profileClass: ProfileClass
+
+    public enum ProfileClass: String, Sendable {
+        case development
+        case adhoc
+        case appstore
+        case enterprise
+    }
+
+    /// Decodes the CMS envelope via `security cms -D` and parses the embedded plist.
+    public init(profileData: Data, shell: any ShellExecuting = DefaultShellExecutor()) throws {
+        try self.init(plist: Self.decodePlist(profileData: profileData, shell: shell))
+    }
+
+    /// Decodes a profile's CMS envelope via `security cms -D` into its plist dictionary.
+    public static func decodePlist(profileData: Data, shell: any ShellExecuting = DefaultShellExecutor()) throws -> [String: Any] {
+        let tempFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).mobileprovision")
+
+        defer {
+            try? FileManager.default.removeItem(at: tempFile)
+        }
+
+        try profileData.write(to: tempFile)
+
+        let output = try shell.run(arguments: ["security", "cms", "-D", "-i", tempFile.path])
+
+        guard let plistData = output.data(using: .utf8),
+              let plist = try? PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any] else {
+            throw Error.invalidProfile("Could not decode profile plist")
+        }
+
+        return plist
+    }
+
+    public init(plist: [String: Any]) throws {
+        guard let uuid = plist["UUID"] as? String else {
+            throw Error.missingKey("UUID")
+        }
+        guard let name = plist["Name"] as? String else {
+            throw Error.missingKey("Name")
+        }
+        guard let creationDate = plist["CreationDate"] as? Date else {
+            throw Error.missingKey("CreationDate")
+        }
+        guard let expirationDate = plist["ExpirationDate"] as? Date else {
+            throw Error.missingKey("ExpirationDate")
+        }
+
+        let entitlements = plist["Entitlements"] as? [String: Any] ?? [:]
+
+        guard let teamId = (plist["TeamIdentifier"] as? [String])?.first
+                ?? entitlements["com.apple.developer.team-identifier"] as? String else {
+            throw Error.missingKey("TeamIdentifier")
+        }
+        guard let applicationIdentifier = entitlements["application-identifier"] as? String else {
+            throw Error.missingKey("Entitlements.application-identifier")
+        }
+
+        self.uuid = uuid
+        self.name = name
+        self.teamId = teamId
+        self.bundleId = applicationIdentifier.hasPrefix("\(teamId).")
+            ? String(applicationIdentifier.dropFirst(teamId.count + 1))
+            : applicationIdentifier
+        self.creationDate = creationDate
+        self.expirationDate = expirationDate
+
+        if plist["ProvisionsAllDevices"] as? Bool == true {
+            self.profileClass = .enterprise
+        } else if plist["ProvisionedDevices"] != nil {
+            self.profileClass = entitlements["get-task-allow"] as? Bool == true ? .development : .adhoc
+        } else {
+            self.profileClass = .appstore
+        }
+    }
+
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidProfile(String)
+        case missingKey(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidProfile(let msg): return msg
+            case .missingKey(let key): return "Profile plist is missing required key: \(key)"
+            }
+        }
+    }
+}

--- a/Sources/Domain/BlimpKit/ProvisioningProfileInfo.swift
+++ b/Sources/Domain/BlimpKit/ProvisioningProfileInfo.swift
@@ -33,7 +33,14 @@ public struct ProvisioningProfileInfo: Sendable {
             try? FileManager.default.removeItem(at: tempFile)
         }
 
-        try profileData.write(to: tempFile)
+        let created = FileManager.default.createFile(
+            atPath: tempFile.path,
+            contents: profileData,
+            attributes: [.posixPermissions: 0o600]
+        )
+        guard created else {
+            throw Error.invalidProfile("Could not write temporary profile file")
+        }
 
         let output = try shell.run(arguments: ["security", "cms", "-D", "-i", tempFile.path])
 

--- a/Tests/Domain/BlimpKit/CertificateInstallerTests.swift
+++ b/Tests/Domain/BlimpKit/CertificateInstallerTests.swift
@@ -36,6 +36,10 @@ final class CertificateInstallerTests: XCTestCase {
         try await mockGit.writeFile(path: "certificates/\(type.rawValue)/\(id).p12", content: encrypted)
     }
 
+    private func storePlainCertificate(id: String, type: ProvisioningAPI.CertificateType, content: String) async throws {
+        try await mockGit.writeFile(path: "certificates/\(type.rawValue)/\(id).p12", content: Data(content.utf8))
+    }
+
     // MARK: - Import
 
     func testImportsDecryptedCertificateWithCodesignAccess() async throws {
@@ -80,6 +84,29 @@ final class CertificateInstallerTests: XCTestCase {
         )
 
         XCTAssertEqual(capturedContent, "ORIGINAL_P12_CONTENT")
+    }
+
+    func testImportsPlainP12WithoutDecryption() async throws {
+        try await storePlainCertificate(id: "CERT123", type: .development, content: "PLAIN_P12_CONTENT")
+
+        var capturedContent: String?
+        mockShell.outputForCommand = { command in
+            if command.contains("security import"), let path = command.split(separator: " ").dropFirst(2).first {
+                capturedContent = try? String(contentsOfFile: String(path), encoding: .utf8)
+            }
+            return ""
+        }
+
+        let installed = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            installWWDR: false
+        )
+
+        XCTAssertEqual(installed.count, 1)
+        XCTAssertEqual(capturedContent, "PLAIN_P12_CONTENT")
     }
 
     func testImportsAllStoredCertificates() async throws {

--- a/Tests/Domain/BlimpKit/CertificateInstallerTests.swift
+++ b/Tests/Domain/BlimpKit/CertificateInstallerTests.swift
@@ -109,6 +109,24 @@ final class CertificateInstallerTests: XCTestCase {
         XCTAssertEqual(capturedContent, "PLAIN_P12_CONTENT")
     }
 
+    func testInstallsSingleP12FromRawData() async throws {
+        try await installer.installCertificate(
+            p12Data: Data("RAW_P12".utf8),
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            keychainPassword: "kc-pass",
+            installWWDR: false
+        )
+
+        let importCommand = mockShell.executedCommands.first { $0.contains("security import") }
+        XCTAssertNotNil(importCommand)
+        XCTAssertTrue(importCommand!.contains("-P \(passphrase)"))
+
+        let partitionCommand = mockShell.executedCommands.first { $0.contains("set-key-partition-list") }
+        XCTAssertNotNil(partitionCommand)
+        XCTAssertTrue(partitionCommand!.contains("-k kc-pass"))
+    }
+
     func testImportsAllStoredCertificates() async throws {
         try await storeEncryptedCertificate(id: "CERT1", type: .distribution)
         try await storeEncryptedCertificate(id: "CERT2", type: .distribution)

--- a/Tests/Domain/BlimpKit/CertificateInstallerTests.swift
+++ b/Tests/Domain/BlimpKit/CertificateInstallerTests.swift
@@ -1,0 +1,266 @@
+import XCTest
+import Foundation
+import ProvisioningAPI
+@testable import BlimpKit
+
+final class CertificateInstallerTests: XCTestCase {
+    var mockGit: MockGitRepo!
+    var mockShell: MockShellExecutor!
+    var mockWWDR: MockWWDRProvider!
+    var installer: CertificateInstaller!
+
+    let passphrase = "test-passphrase"
+    let keychainPath = "/tmp/test.keychain-db"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockGit = MockGitRepo()
+        mockShell = MockShellExecutor()
+        mockWWDR = MockWWDRProvider()
+
+        installer = CertificateInstaller(
+            git: mockGit,
+            shell: mockShell,
+            encrypter: FileEncrypter(),
+            wwdrProvider: mockWWDR
+        )
+    }
+
+    override func tearDown() async throws {
+        await mockGit.cleanup()
+        try await super.tearDown()
+    }
+
+    private func storeEncryptedCertificate(id: String, type: ProvisioningAPI.CertificateType, content: String = "P12_BYTES") async throws {
+        let encrypted = try FileEncrypter().encrypt(data: Data(content.utf8), password: passphrase)
+        try await mockGit.writeFile(path: "certificates/\(type.rawValue)/\(id).p12", content: encrypted)
+    }
+
+    // MARK: - Import
+
+    func testImportsDecryptedCertificateWithCodesignAccess() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development)
+
+        let installed = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            installWWDR: false
+        )
+
+        XCTAssertEqual(installed.count, 1)
+        XCTAssertEqual(installed.first?.certificateId, "CERT123")
+        XCTAssertEqual(installed.first?.keychainPath, keychainPath)
+
+        let importCommand = mockShell.executedCommands.first { $0.contains("security import") }
+        XCTAssertNotNil(importCommand)
+        XCTAssertTrue(importCommand!.contains("-k \(keychainPath)"))
+        XCTAssertTrue(importCommand!.contains("-P \(passphrase)"))
+        XCTAssertTrue(importCommand!.contains("-T /usr/bin/codesign"))
+    }
+
+    func testDecryptedTempFileContentMatchesOriginal() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development, content: "ORIGINAL_P12_CONTENT")
+
+        var capturedContent: String?
+        mockShell.outputForCommand = { command in
+            if command.contains("security import"), let path = command.split(separator: " ").dropFirst(2).first {
+                capturedContent = try? String(contentsOfFile: String(path), encoding: .utf8)
+            }
+            return ""
+        }
+
+        _ = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            installWWDR: false
+        )
+
+        XCTAssertEqual(capturedContent, "ORIGINAL_P12_CONTENT")
+    }
+
+    func testImportsAllStoredCertificates() async throws {
+        try await storeEncryptedCertificate(id: "CERT1", type: .distribution)
+        try await storeEncryptedCertificate(id: "CERT2", type: .distribution)
+
+        let installed = try await installer.installCertificates(
+            platform: .ios,
+            type: .distribution,
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            installWWDR: false
+        )
+
+        XCTAssertEqual(installed.map(\.certificateId).sorted(), ["CERT1", "CERT2"])
+    }
+
+    func testThrowsWhenNoCertificatesInStorage() async {
+        do {
+            _ = try await installer.installCertificates(
+                platform: .ios,
+                type: .development,
+                passphrase: passphrase,
+                keychain: .path(keychainPath),
+                installWWDR: false
+            )
+            XCTFail("Should throw when storage has no certificates")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("No .p12 files"))
+        }
+    }
+
+    func testDecryptionFailureAbortsWithoutImporting() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development)
+
+        let failingInstaller = CertificateInstaller(
+            git: mockGit,
+            shell: mockShell,
+            encrypter: FailingEncrypter(),
+            wwdrProvider: mockWWDR
+        )
+
+        do {
+            _ = try await failingInstaller.installCertificates(
+                platform: .ios,
+                type: .development,
+                passphrase: passphrase,
+                keychain: .path(keychainPath),
+                installWWDR: false
+            )
+            XCTFail("Should throw on decryption failure")
+        } catch {
+            XCTAssertFalse(mockShell.executedCommands.contains { $0.contains("security import") })
+        }
+    }
+
+    // MARK: - Keychain partition list
+
+    func testSetsPartitionListOnlyWhenKeychainPasswordProvided() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development)
+
+        _ = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            keychainPassword: nil,
+            installWWDR: false
+        )
+
+        XCTAssertFalse(mockShell.executedCommands.contains { $0.contains("set-key-partition-list") })
+
+        _ = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            keychainPassword: "keychain-pw",
+            installWWDR: false
+        )
+
+        let partitionCommand = mockShell.executedCommands.first { $0.contains("set-key-partition-list") }
+        XCTAssertNotNil(partitionCommand)
+        XCTAssertTrue(partitionCommand!.contains("-S apple-tool:,apple:,codesign:"))
+        XCTAssertTrue(partitionCommand!.contains("-k keychain-pw"))
+    }
+
+    // MARK: - WWDR
+
+    func testSkipsWWDRWhenAlreadyPresent() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development)
+
+        mockShell.outputForCommand = { command in
+            if command.contains("find-certificate") { return "found" }
+            return ""
+        }
+
+        _ = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath)
+        )
+
+        XCTAssertFalse(mockWWDR.fetchCalled)
+    }
+
+    func testFetchesAndImportsWWDRWhenMissing() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development)
+
+        mockShell.errorForCommand = { command in
+            command.contains("find-certificate") ? MockShellError.commandFailed : nil
+        }
+
+        _ = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath)
+        )
+
+        XCTAssertTrue(mockWWDR.fetchCalled)
+        let wwdrImport = mockShell.executedCommands.first { $0.contains("security import") && $0.contains(".cer") }
+        XCTAssertNotNil(wwdrImport)
+    }
+
+    func testSkipsWWDRWhenDisabled() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development)
+
+        _ = try await installer.installCertificates(
+            platform: .ios,
+            type: .development,
+            passphrase: passphrase,
+            keychain: .path(keychainPath),
+            installWWDR: false
+        )
+
+        XCTAssertFalse(mockWWDR.fetchCalled)
+        XCTAssertFalse(mockShell.executedCommands.contains { $0.contains("find-certificate") })
+    }
+
+    func testThrowsWhenWWDRFetchFailsAndMissing() async throws {
+        try await storeEncryptedCertificate(id: "CERT123", type: .development)
+
+        mockShell.errorForCommand = { command in
+            command.contains("find-certificate") ? MockShellError.commandFailed : nil
+        }
+        mockWWDR.error = MockShellError.commandFailed
+
+        do {
+            _ = try await installer.installCertificates(
+                platform: .ios,
+                type: .development,
+                passphrase: passphrase,
+                keychain: .path(keychainPath)
+            )
+            XCTFail("Should throw when WWDR cannot be fetched")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("WWDR"))
+        }
+    }
+}
+
+// MARK: - Mocks
+
+final class MockWWDRProvider: WWDRCertificateProviding, @unchecked Sendable {
+    var fetchCalled = false
+    var error: Error?
+
+    func fetch() async throws -> Data {
+        fetchCalled = true
+        if let error { throw error }
+        return Data("WWDR_CERT".utf8)
+    }
+}
+
+enum MockShellError: Error {
+    case commandFailed
+}
+
+struct FailingEncrypter: EncryptionService {
+    func encrypt(data: Data, password: String) throws -> Data { data }
+    func decrypt(data: Data, password: String) throws -> Data { throw FileEncrypter.Error.decryptionFailed }
+}

--- a/Tests/Domain/BlimpKit/ProfileInstallerTests.swift
+++ b/Tests/Domain/BlimpKit/ProfileInstallerTests.swift
@@ -171,7 +171,7 @@ final class ProfileInstallerTests: XCTestCase {
             )
             XCTFail("Should throw error for invalid profile")
         } catch {
-            XCTAssertTrue(error.localizedDescription.contains("UUID"))
+            XCTAssertTrue(error.localizedDescription.contains("Could not decode profile plist"))
         }
     }
 

--- a/Tests/Domain/BlimpKit/ProfileInstallerTests.swift
+++ b/Tests/Domain/BlimpKit/ProfileInstallerTests.swift
@@ -251,11 +251,15 @@ final class ProfileInstallerTests: XCTestCase {
 
 class MockShellExecutor: ShellExecuting, @unchecked Sendable {
     var outputForCommand: ((String) -> String)?
+    var errorForCommand: ((String) -> Error?)?
     var executedCommands: [String] = []
 
     func run(arguments: [String]) throws -> String {
         let command = arguments.joined(separator: " ")
         executedCommands.append(command)
+        if let error = errorForCommand?(command) {
+            throw error
+        }
         return outputForCommand?(command) ?? ""
     }
 }

--- a/Tests/Domain/BlimpKit/ProvisioningProfileInfoTests.swift
+++ b/Tests/Domain/BlimpKit/ProvisioningProfileInfoTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import Foundation
+@testable import BlimpKit
+
+final class ProvisioningProfileInfoTests: XCTestCase {
+
+    private func makePlist(
+        getTaskAllow: Bool? = nil,
+        provisionedDevices: [String]? = nil,
+        provisionsAllDevices: Bool? = nil,
+        applicationIdentifier: String = "6NV3U8F9SN.com.example.app"
+    ) -> [String: Any] {
+        var entitlements: [String: Any] = ["application-identifier": applicationIdentifier]
+        if let getTaskAllow {
+            entitlements["get-task-allow"] = getTaskAllow
+        }
+
+        var plist: [String: Any] = [
+            "UUID": "12345678-1234-1234-1234-123456789abc",
+            "Name": "com.example.app",
+            "TeamIdentifier": ["6NV3U8F9SN"],
+            "CreationDate": Date(timeIntervalSince1970: 1_700_000_000),
+            "ExpirationDate": Date(timeIntervalSince1970: 1_730_000_000),
+            "Entitlements": entitlements
+        ]
+        if let provisionedDevices {
+            plist["ProvisionedDevices"] = provisionedDevices
+        }
+        if let provisionsAllDevices {
+            plist["ProvisionsAllDevices"] = provisionsAllDevices
+        }
+        return plist
+    }
+
+    // MARK: - Classification
+
+    func testClassifiesDevelopmentProfile() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist(getTaskAllow: true, provisionedDevices: ["udid1"]))
+        XCTAssertEqual(info.profileClass, .development)
+    }
+
+    func testClassifiesAdhocProfile() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist(getTaskAllow: false, provisionedDevices: ["udid1"]))
+        XCTAssertEqual(info.profileClass, .adhoc)
+    }
+
+    func testClassifiesAdhocProfileWithoutGetTaskAllow() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist(provisionedDevices: ["udid1"]))
+        XCTAssertEqual(info.profileClass, .adhoc)
+    }
+
+    func testClassifiesAppStoreProfile() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist())
+        XCTAssertEqual(info.profileClass, .appstore)
+    }
+
+    func testClassifiesEnterpriseProfile() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist(provisionsAllDevices: true))
+        XCTAssertEqual(info.profileClass, .enterprise)
+    }
+
+    // MARK: - Fields
+
+    func testExtractsBundleIdWithoutTeamPrefix() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist())
+        XCTAssertEqual(info.teamId, "6NV3U8F9SN")
+        XCTAssertEqual(info.bundleId, "com.example.app")
+    }
+
+    func testKeepsWildcardBundleId() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist(applicationIdentifier: "6NV3U8F9SN.*"))
+        XCTAssertEqual(info.bundleId, "*")
+    }
+
+    func testParsesDates() throws {
+        let info = try ProvisioningProfileInfo(plist: makePlist())
+        XCTAssertEqual(info.creationDate, Date(timeIntervalSince1970: 1_700_000_000))
+        XCTAssertEqual(info.expirationDate, Date(timeIntervalSince1970: 1_730_000_000))
+    }
+
+    // MARK: - Errors
+
+    func testThrowsOnMissingUUID() {
+        var plist = makePlist()
+        plist["UUID"] = nil
+
+        XCTAssertThrowsError(try ProvisioningProfileInfo(plist: plist)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("UUID"))
+        }
+    }
+
+    func testThrowsOnMissingApplicationIdentifier() {
+        var plist = makePlist()
+        plist["Entitlements"] = [String: Any]()
+
+        XCTAssertThrowsError(try ProvisioningProfileInfo(plist: plist)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("application-identifier"))
+        }
+    }
+
+    func testThrowsOnMissingCreationDate() {
+        var plist = makePlist()
+        plist["CreationDate"] = nil
+
+        XCTAssertThrowsError(try ProvisioningProfileInfo(plist: plist)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("CreationDate"))
+        }
+    }
+
+    // MARK: - CMS decoding
+
+    func testDecodesPlistViaShell() throws {
+        let mockShell = MockShellExecutor()
+        mockShell.outputForCommand = { _ in
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <plist version="1.0">
+            <dict>
+                <key>UUID</key>
+                <string>test-uuid</string>
+            </dict>
+            </plist>
+            """
+        }
+
+        let plist = try ProvisioningProfileInfo.decodePlist(
+            profileData: Data("fake".utf8),
+            shell: mockShell
+        )
+
+        XCTAssertEqual(plist["UUID"] as? String, "test-uuid")
+        XCTAssertTrue(mockShell.executedCommands.first?.contains("security cms -D") == true)
+    }
+}


### PR DESCRIPTION
## What

Adds the keychain half of local signing setup, so consumers (Platamator's upcoming `sign install` command) can install both profiles **and** certificates from Blimp-managed git storage without ASC credentials.

- **`CertificateInstaller`** (BlimpKit): reads `certificates/<TYPE>/*.p12` from git storage, decrypts with the storage passphrase, imports into a keychain via `security import -T /usr/bin/codesign`, installs the Apple WWDR G3 intermediate when missing (injectable provider, no hard network dependency in tests), and optionally runs `security set-key-partition-list` to suppress codesign UI prompts.
- **`ProvisioningProfileInfo`** (BlimpKit): parses `.mobileprovision` metadata — UUID, name, team id, bundle id (team prefix stripped), creation/expiration dates — and classifies development / adhoc / appstore / enterprise from the plist (`ProvisionedDevices` + `get-task-allow` + `ProvisionsAllDevices`). Needed by the old↔new signing repo syncer, where profile type must come from content, not filenames. The CMS decode (`security cms -D`) is shared with `ProfileInstaller`, which keeps its lenient UUID-only behavior.
- **CLI**: `blimp maintenance install-certs` (passphrase via `CERTIFICATE_PASSWORD` / flag / hidden prompt; keychain password via `KEYCHAIN_PASSWORD`). Passphrase prompt logic extracted into a shared helper used by `generate-cert` too.

## Tests

158 tests pass (`swift test`), including new suites:
- `CertificateInstallerTests`: real FileEncrypter round-trip, exact `security import` args, partition-list gating, WWDR skip/fetch/failure paths, decrypt-failure abort
- `ProvisioningProfileInfoTests`: classification matrix, bundle-id/team-id extraction, wildcard handling, missing-key errors

## Notes

- Decryption failure with a wrong passphrase is covered in `FileEncrypterTests`; the installer test injects a failing encrypter instead (CBC+PKCS7 wrong-key detection is probabilistic).
- Suggested release: **0.8.0** (additive).