### PR TITLE
chore: corredor 1.2.0, Shell.arguments executes argv directly

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5adc7166c305f310a091b45fcba2771fa3f8b75a652d7797ac5193fe5697f900",
+  "originHash" : "dba9fe98537638a8fadf2146cdd2fc6d172f5a7f4fa7d609bb65119f0408162d",
   "pins" : [
     {
       "identity" : "corredor",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/platacard/corredor",
       "state" : {
-        "revision" : "32045bed631d5d91636dff44d94f57e5a4a957e1",
-        "version" : "1.1.0"
+        "revision" : "beb130cd7745b261f701c23fa66bb85468591e0e",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.8.3"),
         .package(url: "https://github.com/apple/swift-openapi-urlsession", exact: "1.1.0"),
         .package(url: "https://github.com/platacard/cronista", from: "1.1.0"),
-        .package(url: "https://github.com/platacard/corredor", from: "1.1.0"),
+        .package(url: "https://github.com/platacard/corredor", from: "1.2.0"),
         .package(url: "https://github.com/platacard/dotcontext.git", from: "1.0.1"),
         .package(url: "https://github.com/platacard/gito.git", from: "1.1.0")
     ],


### PR DESCRIPTION
Picks up platacard/corredor#6: the arguments API no longer routes through zsh, so p12/keychain passwords with shell-special characters survive install-certs and set-key-partition-list, and zsh can no longer echo them into error output. No blimp code changes needed.