### PR TITLE
feat: opt-in certificate rotation for generate-cert

### DIFF
--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -7,7 +7,7 @@ import Cronista
 struct GenerateCertificate: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "generate-cert",
-        abstract: "Generate and store a new certificate"
+        abstract: "Rotate the certificate of a type: generate a new one, revoke the previous"
     )
 
     @Option(help: "Certificate type: development, distribution")

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -7,7 +7,7 @@ import Cronista
 struct GenerateCertificate: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "generate-cert",
-        abstract: "Rotate the certificate of a type: generate a new one, revoke the previous"
+        abstract: "Rotate the certificate of a type: generate a new one, revoke all previous of that type"
     )
 
     @Option(help: "Certificate type: development, distribution")

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -25,8 +25,14 @@ struct GenerateCertificate: AsyncParsableCommand {
     @Flag(help: "Push to remote after committing")
     var push: Bool = false
 
-    @Flag(help: "Revoke all previous certificates of the type and prune their stored p12s")
+    @Flag(help: "Revoke all previous certificates of the type and prune their stored p12s (requires --push)")
     var rotate: Bool = false
+
+    func validate() throws {
+        if rotate && !push {
+            throw ValidationError("--rotate requires --push: revocation makes the new certificate the only valid one, so its p12 must reach the shared storage")
+        }
+    }
 
     func run() async throws {
         let logger = Cronista(module: "blimp", category: "Maintenance")

--- a/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
+++ b/Sources/CLI/BlimpCLI/Subcommands/Maintenance/Subcommands/Certs/GenerateCertificate.swift
@@ -7,7 +7,7 @@ import Cronista
 struct GenerateCertificate: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "generate-cert",
-        abstract: "Rotate the certificate of a type: generate a new one, revoke all previous of that type"
+        abstract: "Generate and store a new certificate; --rotate revokes all previous of the type"
     )
 
     @Option(help: "Certificate type: development, distribution")
@@ -25,6 +25,9 @@ struct GenerateCertificate: AsyncParsableCommand {
     @Flag(help: "Push to remote after committing")
     var push: Bool = false
 
+    @Flag(help: "Revoke all previous certificates of the type and prune their stored p12s")
+    var rotate: Bool = false
+
     func run() async throws {
         let logger = Cronista(module: "blimp", category: "Maintenance")
         let passphrase = try resolveSecret(
@@ -39,7 +42,8 @@ struct GenerateCertificate: AsyncParsableCommand {
             platform: platform,
             storagePath: resolvedPath,
             passphrase: passphrase,
-            push: push
+            push: push,
+            rotate: rotate
         )
 
         logger.info("Certificate created successfully")

--- a/Sources/Domain/BlimpKit/CertificateManager.swift
+++ b/Sources/Domain/BlimpKit/CertificateManager.swift
@@ -85,6 +85,52 @@ public struct CertificateManager: Sendable {
         return cert
     }
 
+    /// Creates a new certificate, then revokes every other portal certificate of the
+    /// same type and prunes their stored p12s — storage and portal end with exactly one.
+    public func rotateCertificate(
+        type: ProvisioningAPI.CertificateType,
+        platform: ProvisioningAPI.Platform
+    ) async throws -> ProvisioningAPI.Certificate {
+        try await git.cloneOrPull()
+
+        let certDir = type.storageDirectory(for: platform)
+
+        let (csr, privateKey) = try certGenerator.generateCSR()
+        let cert = try await certificateService.createCertificate(csrContent: csr, type: type)
+        guard let certContent = cert.content else {
+            throw Error.missingData("Certificate created but no content returned")
+        }
+
+        let p12 = try certGenerator.generateP12(certContent: certContent, privateKey: privateKey, passphrase: passphrase)
+        try await git.writeFile(path: "\(certDir)/\(cert.id).p12", content: p12)
+
+        let stale = try await certificateService.listCertificates(filterType: type)
+            .map(\.id)
+            .filter { $0 != cert.id }
+
+        for id in stale {
+            try await certificateService.deleteCertificate(id: id)
+            logger.info("Revoked certificate \(id)")
+        }
+
+        let dirURL = git.localURL.appendingPathComponent(certDir)
+        if let files = try? FileManager.default.contentsOfDirectory(atPath: dirURL.path) {
+            for file in files where file.hasSuffix(".p12") && file != "\(cert.id).p12" {
+                try FileManager.default.removeItem(at: dirURL.appendingPathComponent(file))
+                logger.info("Removed stored \(file)")
+            }
+        }
+
+        try await git.commitAndPush(
+            message: "Rotate certificate \(cert.id) for \(platform.rawValue) \(type.rawValue)"
+                + (stale.isEmpty ? "" : ", revoked \(stale.joined(separator: ", "))"),
+            push: push
+        )
+
+        logger.info("Rotated certificate: \(cert.id)")
+        return cert
+    }
+
     /// Finds an existing valid certificate or creates a new one.
     /// - Parameters:
     ///   - type: Certificate type

--- a/Sources/Domain/BlimpKit/CertificateManager.swift
+++ b/Sources/Domain/BlimpKit/CertificateManager.swift
@@ -114,11 +114,10 @@ public struct CertificateManager: Sendable {
         }
 
         let dirURL = git.localURL.appendingPathComponent(certDir)
-        if let files = try? FileManager.default.contentsOfDirectory(atPath: dirURL.path) {
-            for file in files where file.hasSuffix(".p12") && file != "\(cert.id).p12" {
-                try FileManager.default.removeItem(at: dirURL.appendingPathComponent(file))
-                logger.info("Removed stored \(file)")
-            }
+        let files = try FileManager.default.contentsOfDirectory(atPath: dirURL.path)
+        for file in files where file.hasSuffix(".p12") && file != "\(cert.id).p12" {
+            try FileManager.default.removeItem(at: dirURL.appendingPathComponent(file))
+            logger.info("Removed stored \(file)")
         }
 
         try await git.commitAndPush(

--- a/Sources/Domain/BlimpKit/CertificateManager.swift
+++ b/Sources/Domain/BlimpKit/CertificateManager.swift
@@ -87,6 +87,8 @@ public struct CertificateManager: Sendable {
 
     /// Creates a new certificate, then revokes every other portal certificate of the
     /// same type and prunes their stored p12s — storage and portal end with exactly one.
+    /// The new p12 is committed and pushed before any revocation, so a failed push
+    /// never leaves remote storage without the p12 of the only valid certificate.
     public func rotateCertificate(
         type: ProvisioningAPI.CertificateType,
         platform: ProvisioningAPI.Platform
@@ -103,6 +105,10 @@ public struct CertificateManager: Sendable {
 
         let p12 = try certGenerator.generateP12(certContent: certContent, privateKey: privateKey, passphrase: passphrase)
         try await git.writeFile(path: "\(certDir)/\(cert.id).p12", content: p12)
+        try await git.commitAndPush(
+            message: "Add certificate \(cert.id) for \(platform.rawValue) \(type.rawValue)",
+            push: push
+        )
 
         let stale = try await certificateService.listCertificates(filterType: type)
             .map(\.id)
@@ -120,11 +126,12 @@ public struct CertificateManager: Sendable {
             logger.info("Removed stored \(file)")
         }
 
-        try await git.commitAndPush(
-            message: "Rotate certificate \(cert.id) for \(platform.rawValue) \(type.rawValue)"
-                + (stale.isEmpty ? "" : ", revoked \(stale.joined(separator: ", "))"),
-            push: push
-        )
+        if !stale.isEmpty {
+            try await git.commitAndPush(
+                message: "Prune revoked certificates \(stale.joined(separator: ", ")) for \(platform.rawValue) \(type.rawValue)",
+                push: push
+            )
+        }
 
         logger.info("Rotated certificate: \(cert.id)")
         return cert

--- a/Sources/Domain/BlimpKit/Stages/1_Maintenance.swift
+++ b/Sources/Domain/BlimpKit/Stages/1_Maintenance.swift
@@ -65,7 +65,7 @@ public extension Blimp {
                 push: push
             )
 
-            return try await manager.createAndStoreCertificate(type: type, platform: platform)
+            return try await manager.rotateCertificate(type: type, platform: platform)
         }
 
         /// Finds a valid certificate ID from storage that matches Apple Developer Portal.

--- a/Sources/Domain/BlimpKit/Stages/1_Maintenance.swift
+++ b/Sources/Domain/BlimpKit/Stages/1_Maintenance.swift
@@ -52,7 +52,8 @@ public extension Blimp {
             platform: ProvisioningAPI.Platform,
             storagePath: String,
             passphrase: String,
-            push: Bool = false
+            push: Bool = false,
+            rotate: Bool = false
         ) async throws -> ProvisioningAPI.Certificate {
             let git = GitStorage(localPath: storagePath)
             let certGenerator = OpenSSLCertificateGenerator()
@@ -65,7 +66,9 @@ public extension Blimp {
                 push: push
             )
 
-            return try await manager.rotateCertificate(type: type, platform: platform)
+            return rotate
+                ? try await manager.rotateCertificate(type: type, platform: platform)
+                : try await manager.createAndStoreCertificate(type: type, platform: platform)
         }
 
         /// Finds a valid certificate ID from storage that matches Apple Developer Portal.

--- a/Sources/Domain/BlimpKit/Stages/1_Maintenance.swift
+++ b/Sources/Domain/BlimpKit/Stages/1_Maintenance.swift
@@ -55,6 +55,10 @@ public extension Blimp {
             push: Bool = false,
             rotate: Bool = false
         ) async throws -> ProvisioningAPI.Certificate {
+            if rotate && !push {
+                throw MaintenanceError.rotateRequiresPush
+            }
+
             let git = GitStorage(localPath: storagePath)
             let certGenerator = OpenSSLCertificateGenerator()
 
@@ -239,11 +243,14 @@ public extension Blimp {
         public enum MaintenanceError: Error, LocalizedError {
             case missingData(String)
             case certificateNotFound(String)
+            case rotateRequiresPush
 
             public var errorDescription: String? {
                 switch self {
                 case .missingData(let msg): return msg
                 case .certificateNotFound(let msg): return msg
+                case .rotateRequiresPush:
+                    return "Rotation revokes portal certificates, so the replacement p12 must reach the shared storage: pass push together with rotate"
                 }
             }
         }

--- a/Tests/Domain/BlimpKit/CertificateManagerTests.swift
+++ b/Tests/Domain/BlimpKit/CertificateManagerTests.swift
@@ -22,6 +22,24 @@ final class CertificateManagerTests: XCTestCase {
         )
     }
 
+    // MARK: - Rotation
+
+    func testRotateRevokesOtherCertsOfTypeAndPrunesStorage() async throws {
+        let oldDev = try await mockCertService.createCertificate(csrContent: "csr", type: .development)
+        let dist = try await mockCertService.createCertificate(csrContent: "csr", type: .distribution)
+        try await mockGit.writeFile(path: "certificates/DEVELOPMENT/\(oldDev.id).p12", content: Data("OLD".utf8))
+
+        let cert = try await manager.rotateCertificate(type: .development, platform: .ios)
+
+        let deleted = mockCertService.deletedCertificateIds
+        XCTAssertEqual(deleted, [oldDev.id])
+        XCTAssertFalse(deleted.contains(dist.id))
+
+        let dir = await mockGit.localURL.appendingPathComponent("certificates/DEVELOPMENT")
+        let files = try FileManager.default.contentsOfDirectory(atPath: dir.path).filter { $0.hasSuffix(".p12") }
+        XCTAssertEqual(files, ["\(cert.id).p12"])
+    }
+
     // MARK: - Find Certificate Tests
 
     func testFindValidCertificateReturnsIdWhenExists() async throws {

--- a/Tests/Domain/BlimpKit/CertificateManagerTests.swift
+++ b/Tests/Domain/BlimpKit/CertificateManagerTests.swift
@@ -38,6 +38,11 @@ final class CertificateManagerTests: XCTestCase {
         let dir = await mockGit.localURL.appendingPathComponent("certificates/DEVELOPMENT")
         let files = try FileManager.default.contentsOfDirectory(atPath: dir.path).filter { $0.hasSuffix(".p12") }
         XCTAssertEqual(files, ["\(cert.id).p12"])
+
+        let commits = await mockGit.pushedCommits
+        XCTAssertEqual(commits.count, 2)
+        XCTAssertTrue(commits[0].contains("Add certificate \(cert.id)"))
+        XCTAssertTrue(commits[1].contains("Prune revoked certificates \(oldDev.id)"))
     }
 
     func testRotateFailedCreationRevokesAndDeletesNothing() async throws {

--- a/Tests/Domain/BlimpKit/CertificateManagerTests.swift
+++ b/Tests/Domain/BlimpKit/CertificateManagerTests.swift
@@ -40,6 +40,21 @@ final class CertificateManagerTests: XCTestCase {
         XCTAssertEqual(files, ["\(cert.id).p12"])
     }
 
+    func testRotateFailedCreationRevokesAndDeletesNothing() async throws {
+        let oldDev = try await mockCertService.createCertificate(csrContent: "csr", type: .development)
+        try await mockGit.writeFile(path: "certificates/DEVELOPMENT/\(oldDev.id).p12", content: Data("OLD".utf8))
+        mockCertService.createError = NSError(domain: "asc", code: 1)
+
+        do {
+            _ = try await manager.rotateCertificate(type: .development, platform: .ios)
+            XCTFail("Expected creation failure")
+        } catch {}
+
+        XCTAssertTrue(mockCertService.deletedCertificateIds.isEmpty)
+        let stillStored = await mockGit.fileExists(path: "certificates/DEVELOPMENT/\(oldDev.id).p12")
+        XCTAssertTrue(stillStored)
+    }
+
     // MARK: - Find Certificate Tests
 
     func testFindValidCertificateReturnsIdWhenExists() async throws {

--- a/Tests/Domain/BlimpKit/Mocks.swift
+++ b/Tests/Domain/BlimpKit/Mocks.swift
@@ -85,6 +85,7 @@ class MockCertificateGenerator: CertificateGenerating, @unchecked Sendable {
 class MockCertificateService: CertificateService, @unchecked Sendable {
     var certificates: [ProvisioningAPI.Certificate] = []
     var deletedCertificateIds: [String] = []
+    var createError: Error?
 
     func listCertificates(filterType: ProvisioningAPI.CertificateType?) async throws -> [ProvisioningAPI.Certificate] {
         if let filter = filterType {
@@ -94,6 +95,7 @@ class MockCertificateService: CertificateService, @unchecked Sendable {
     }
 
     func createCertificate(csrContent: String, type: ProvisioningAPI.CertificateType) async throws -> ProvisioningAPI.Certificate {
+        if let createError { throw createError }
         let cert = ProvisioningAPI.Certificate(
             id: UUID().uuidString,
             name: "Mock Cert",


### PR DESCRIPTION
Match semantics for certificate generation, opt-in:

- New CertificateManager.rotateCertificate: creates the new certificate first (old ones stay valid if creation fails), then revokes every other portal certificate of the same type and prunes their stored p12s - storage and portal end with exactly one.
- generateCertificate / generate-cert CLI gain rotate (--rotate), default false: the default behavior stays purely additive, exactly as before.
- ensureCertificate keeps its reuse semantics - it only creates when no valid stored certificate exists, and never revokes.
- Failure-mode test locks the ordering guarantee: a failed creation revokes and deletes nothing.