### PR TITLE
fix: batch profile sync into one commit per run

### DIFF
--- a/Sources/Domain/BlimpKit/ProfileSyncCoordinator.swift
+++ b/Sources/Domain/BlimpKit/ProfileSyncCoordinator.swift
@@ -45,8 +45,10 @@ public struct ProfileSyncCoordinator: Sendable {
 
         try await git.cloneOrPull()
 
+        var updated: [String] = []
+
         for entry in bundleIds {
-            try await syncProfile(
+            let synced = try await syncProfile(
                 bundleId: entry.bundleId,
                 profileName: entry.profileName,
                 type: type,
@@ -54,6 +56,13 @@ public struct ProfileSyncCoordinator: Sendable {
                 certificateIds: certificateIds,
                 force: force
             )
+            if synced {
+                updated.append(entry.profileName)
+            }
+        }
+
+        if !updated.isEmpty {
+            try await git.commitAndPush(message: "Update \(typeLabel(type)) profiles", push: push)
         }
 
         logger.info("Profile sync completed successfully.")
@@ -66,7 +75,7 @@ public struct ProfileSyncCoordinator: Sendable {
         platform: ProvisioningAPI.Platform,
         certificateIds: [String],
         force: Bool
-    ) async throws {
+    ) async throws -> Bool {
         let profileDir = "profiles/\(platform.rawValue)/\(type.rawValue)"
         let fileName = "\(profileName).mobileprovision"
         let filePath = "\(profileDir)/\(fileName)"
@@ -75,7 +84,7 @@ public struct ProfileSyncCoordinator: Sendable {
 
         if !force && fileExists {
             logger.info("Profile \(profileName) exists in storage, skipping.")
-            return
+            return false
         }
 
         if force {
@@ -107,9 +116,19 @@ public struct ProfileSyncCoordinator: Sendable {
         }
 
         try await git.writeFile(path: filePath, content: content)
-        try await git.commitAndPush(message: "Update profile \(profileName)", push: push)
 
         logger.info("Synced profile: \(profileName)")
+        return true
+    }
+
+    private func typeLabel(_ type: ProvisioningAPI.ProfileType) -> String {
+        switch type {
+        case .iosAppDevelopment, .macAppDevelopment, .tvosAppDevelopment, .macCatalystAppDevelopment: "development"
+        case .iosAppStore, .macAppStore, .tvosAppStore, .macCatalystAppStore: "appstore"
+        case .iosAppAdhoc, .tvosAppAdhoc: "adhoc"
+        case .iosAppInhouse, .tvosAppInhouse: "inhouse"
+        case .macAppDirect, .macCatalystAppDirect: "direct"
+        }
     }
 
     private func resolveDeviceIds(type: ProvisioningAPI.ProfileType, platform: ProvisioningAPI.Platform) async throws -> [String]? {

--- a/Tests/Domain/BlimpKit/ProfileSyncCoordinatorTests.swift
+++ b/Tests/Domain/BlimpKit/ProfileSyncCoordinatorTests.swift
@@ -117,6 +117,27 @@ final class ProfileSyncCoordinatorTests: XCTestCase {
             let exists = await mockGit.fileExists(path: profilePath)
             XCTAssertTrue(exists, "Profile for \(bundleId) should exist")
         }
+
+        let commits = await mockGit.pushedCommits
+        XCTAssertEqual(commits, ["Update appstore profiles"], "All synced profiles should land in one commit")
+    }
+
+    func testSyncDoesNotCommitWhenNothingChanged() async throws {
+        let bundleId = "com.example.app"
+        mockProfileService.bundleIds[bundleId] = "bundle-resource-id"
+
+        let profilePath = "profiles/ios/IOS_APP_DEVELOPMENT/\(bundleId).mobileprovision"
+        try await mockGit.writeFile(path: profilePath, content: Data())
+
+        try await coordinator.sync(
+            platform: .ios,
+            type: .iosAppDevelopment,
+            bundleIds: [(bundleId, bundleId)],
+            certificateIds: ["cert-123"]
+        )
+
+        let commits = await mockGit.pushedCommits
+        XCTAssertTrue(commits.isEmpty, "Skipped profiles should not produce a commit")
     }
 
     func testSyncWithCustomProfileName() async throws {


### PR DESCRIPTION
sync-profiles committed after every profile, so a full run flooded the storage repo with a dozen `Update profile <name>` commits (screenshot-worthy in the swift-signing history). The coordinator now writes all profiles during the loop and commits once at the end — `Update development profiles` / `Update adhoc profiles` / `Update appstore profiles` depending on the type. Runs where every profile is skipped produce no commit.

Tests: batching asserted on the multi-bundle sync, plus a no-changes-no-commit case.